### PR TITLE
changed the code to read the default lifecycles from multiple files from...

### DIFF
--- a/components/governance/org.wso2.carbon.governance.lcm/src/main/java/org/wso2/carbon/governance/lcm/internal/LCMServiceComponent.java
+++ b/components/governance/org.wso2.carbon.governance.lcm/src/main/java/org/wso2/carbon/governance/lcm/internal/LCMServiceComponent.java
@@ -15,6 +15,8 @@
  */
 package org.wso2.carbon.governance.lcm.internal;
 
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceRegistration;
 import org.osgi.service.component.ComponentContext;
 import org.wso2.carbon.CarbonConstants;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
@@ -25,6 +27,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.core.services.callback.LoginSubscriptionManagerService;
 import org.wso2.carbon.registry.core.utils.UUIDGenerator;
+import org.wso2.carbon.utils.Axis2ConfigurationContextObserver;
 import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 
 /**
@@ -33,20 +36,30 @@ import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
  * @scr.reference name="registry.service"
  * interface="org.wso2.carbon.registry.core.service.RegistryService" cardinality="1..1"
  * policy="dynamic" bind="setRegistryService" unbind="unsetRegistryService"
- * @scr.reference name="login.subscription.service"
- * interface="org.wso2.carbon.core.services.callback.LoginSubscriptionManagerService" cardinality="0..1"
- * policy="dynamic" bind="setLoginSubscriptionManagerService" unbind="unsetLoginSubscriptionManagerService"
  */
 public class LCMServiceComponent {
 
     private static Log log = LogFactory.getLog(LCMServiceComponent.class);
 
     protected void activate(ComponentContext context) {
-        log.debug("******* Governance Life Cycle Management Service bundle is activated ******* ");
+        BundleContext bundleContext = context.getBundleContext();
+        LifecycleLoader lifecycleLoader = new LifecycleLoader();
+        ServiceRegistration tenantMgtListenerSR = bundleContext.registerService(
+                Axis2ConfigurationContextObserver.class.getName(), lifecycleLoader, null);
+        if (tenantMgtListenerSR != null) {
+            log.debug("Governance Life Cycle Management - LifecycleLoader registered");
+        } else {
+            log.error("Governance Life Cycle Management - LifecycleLoader could not be registered");
+        }
+        if (log.isDebugEnabled()) {
+            log.debug("Governance Life Cycle Management Service bundle is activated");
+        }
     }
 
     protected void deactivate(ComponentContext context) {
-        log.debug("******* Governance Life Cycle Management Service bundle is deactivated ******* ");
+        if(log.isDebugEnabled()) {
+            log.debug("Governance Life Cycle Management Service bundle is deactivated");
+        }
     }
 
     protected void setRegistryService(RegistryService registryService) {
@@ -58,7 +71,7 @@ public class LCMServiceComponent {
         // Generate LCM search query if it doesn't exist.
         try {
             CommonUtil.addDefaultLifecyclesIfNotAvailable(registryService.getConfigSystemRegistry(),
-                    registryService.getRegistry(CarbonConstants.REGISTRY_SYSTEM_USERNAME), false);
+                    registryService.getRegistry(CarbonConstants.REGISTRY_SYSTEM_USERNAME));
         } catch (Exception e) {
             log.error("An error occurred while setting up Governance Life Cycle Management", e);
         }
@@ -66,14 +79,5 @@ public class LCMServiceComponent {
 
     protected void unsetRegistryService(RegistryService registryService) {
         CommonUtil.setRegistryService(null);
-    }
-
-    protected void setLoginSubscriptionManagerService(LoginSubscriptionManagerService loginManager) {
-        log.debug("******* LoginSubscriptionManagerServic is set ******* ");
-        loginManager.subscribe(new LifecycleLoader());
-    }
-
-    protected void unsetLoginSubscriptionManagerService(LoginSubscriptionManagerService loginManager) {
-        log.debug("******* LoginSubscriptionManagerServic is unset ******* ");
     }
 }

--- a/components/governance/org.wso2.carbon.governance.lcm/src/main/java/org/wso2/carbon/governance/lcm/internal/LCMServiceComponent.java
+++ b/components/governance/org.wso2.carbon.governance.lcm/src/main/java/org/wso2/carbon/governance/lcm/internal/LCMServiceComponent.java
@@ -47,7 +47,9 @@ public class LCMServiceComponent {
         ServiceRegistration tenantMgtListenerSR = bundleContext.registerService(
                 Axis2ConfigurationContextObserver.class.getName(), lifecycleLoader, null);
         if (tenantMgtListenerSR != null) {
-            log.debug("Governance Life Cycle Management - LifecycleLoader registered");
+            if(log.isDebugEnabled()) {
+                log.debug("Governance Life Cycle Management - LifecycleLoader registered");
+            }
         } else {
             log.error("Governance Life Cycle Management - LifecycleLoader could not be registered");
         }

--- a/components/governance/org.wso2.carbon.governance.lcm/src/main/java/org/wso2/carbon/governance/lcm/util/CommonUtil.java
+++ b/components/governance/org.wso2.carbon.governance.lcm/src/main/java/org/wso2/carbon/governance/lcm/util/CommonUtil.java
@@ -24,6 +24,8 @@ import org.apache.axiom.om.OMNode;
 import org.apache.axiom.om.OMText;
 import org.apache.axiom.om.util.AXIOMUtil;
 import org.apache.axiom.om.xpath.AXIOMXPath;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.CarbonConstants;
@@ -268,8 +270,11 @@ public class CommonUtil {
         validateOMContent(element);
         name = element.getAttributeValue(new QName("name"));
 
-        if (isLifecycleNameInUse(name, registry, rootRegistry))
-            throw new RegistryException("The added lifecycle name is already in use!");
+        if (isLifecycleNameInUse(name, registry, rootRegistry)){
+            String msg = String.format("The lifecycle name %s is already in use", name);
+            log.error(msg);
+            return false;
+        }
 
         String path = getContextRoot() + name;
         Resource resource;
@@ -442,54 +447,62 @@ public class CommonUtil {
         CommonUtil.contextRoot = contextRoot;
     }
 
-    public static boolean addDefaultLifecyclesIfNotAvailable(Registry registry, Registry rootRegistry,
-                                                             boolean generateOnly)
+    public static boolean addDefaultLifecyclesIfNotAvailable(Registry registry, Registry rootRegistry)
             throws RegistryException, FileNotFoundException, XMLStreamException {
-        if (!generateOnly && !registry.resourceExists(RegistryConstants.LIFECYCLE_CONFIGURATION_PATH)) {
+
+        if (!registry.resourceExists(RegistryConstants.LIFECYCLE_CONFIGURATION_PATH)) {
             Collection lifeCycleConfigurationCollection = new CollectionImpl();
-            String description = "Lifecycle configurations are stored here.";
-            lifeCycleConfigurationCollection.setDescription(description);
             registry.put(RegistryConstants.LIFECYCLE_CONFIGURATION_PATH, lifeCycleConfigurationCollection);
-
-            String defaultLifecycleConfig = System.getProperty(ServerConstants.CARBON_HOME) + File.separator+ "repository" +
-                    File.separator + "resources" + File.separator + "lifecycles" + File.separator + "configurations.xml";
-
-            StringBuilder sb = new StringBuilder();
-            try {
-                BufferedReader in = new BufferedReader(new FileReader(defaultLifecycleConfig));
-                String str;
-                while ((str = in.readLine()) != null) {
-                    sb.append(str).append("\n");
-                }
-                in.close();
-            } catch (IOException e) {
-                throw new RegistryException(e.toString());
-            }
-
-            addLifecycle(sb.toString(), registry, rootRegistry);
         }
-        else {
-            // invoke all the aspects with configurations for lifecycles
-            Resource lifecycleRoot = registry.get(getContextRoot());
-            if (!(lifecycleRoot instanceof Collection)) {
-                String msg = "Failed to continue as the lifecycle configuration root: " + getContextRoot() +
-                        " is not a collection.";
-                log.error(msg);
-                throw new RegistryException(msg);
+
+        String defaultLifecycleConfigLocation = getDefaltLifecycleConfigLocation();
+        File defaultLifecycleConfigDirectory = new File(defaultLifecycleConfigLocation);
+        if (!defaultLifecycleConfigDirectory.exists()) {
+            return false;
+        }
+
+        FilenameFilter filenameFilter = new FilenameFilter() {
+            @Override
+            public boolean accept(File file, String name) {
+                return name.endsWith(".xml");
             }
-            Collection lifecycleRootCol = (Collection)lifecycleRoot;
-            String[] lifecycleConfigPaths = lifecycleRootCol.getChildren();
-            if (lifecycleConfigPaths != null) {
-                for (String lifecycleConfigPath: lifecycleConfigPaths) {
-                    generateAspect(lifecycleConfigPath, registry);
+        };
+        File[] lifecycleConfigFiles = defaultLifecycleConfigDirectory.listFiles(filenameFilter);
+        if (lifecycleConfigFiles.length == 0) {
+            return false;
+        }
+
+        for (File lifecycleConfigFile : lifecycleConfigFiles) {
+            String fileName = FilenameUtils.removeExtension(lifecycleConfigFile.getName());
+            //here configuration file name should be same as aspect name
+            String resourceName = RegistryConstants.LIFECYCLE_CONFIGURATION_PATH + fileName;
+            String fileContent = null;
+
+            if (!registry.resourceExists(resourceName)) {
+                try {
+                    fileContent = FileUtils.readFileToString(lifecycleConfigFile);
+                } catch (IOException e) {
+                    String msg = String.format("Error while reading lifecycle config file %s ", fileName);
+                    log.error(msg, e);
                 }
+                if ((fileContent != null) && !fileContent.isEmpty()) {
+                    addLifecycle(fileContent, registry, rootRegistry);
+                }
+            } else {
+                generateAspect(resourceName, registry);
             }
         }
 
         return true;
     }
 
-    public static boolean isLifecycleNameInUse(String name, Registry registry, Registry rootRegistry) throws RegistryException, XMLStreamException {
+    public static String getDefaltLifecycleConfigLocation() {
+        return System.getProperty(ServerConstants.CARBON_HOME) + File.separator + "repository" +
+               File.separator + "resources" + File.separator + "lifecycles";
+    }
+
+    public static boolean isLifecycleNameInUse(String name, Registry registry, Registry rootRegistry)
+            throws RegistryException, XMLStreamException {
         if (name.contains("<aspect")) {
             OMElement element = AXIOMUtil.stringToOM(name);
             if (element != null) {

--- a/components/ws-discovery-proxy/org.wso2.carbon.discovery.proxy/src/main/java/org/wso2/carbon/discovery/proxy/util/DiscoveryServiceUtils.java
+++ b/components/ws-discovery-proxy/org.wso2.carbon.discovery.proxy/src/main/java/org/wso2/carbon/discovery/proxy/util/DiscoveryServiceUtils.java
@@ -49,9 +49,6 @@ import java.util.*;
  * Carbon governance components create and manage services discovered through WS-D.
  */
 public class DiscoveryServiceUtils {
-	
-	private static final String DEFAULT_SERVICE_VERSION = "1.0.0";
-	private static final String SERVICE_VERSION_PREFIX = "overview_version";
 
     private static Registry getRegistry() throws DiscoveryException {
         return (Registry) PrivilegedCarbonContext.getThreadLocalCarbonContext().
@@ -100,7 +97,7 @@ public class DiscoveryServiceUtils {
         Service newService = serviceManager.newService(new QName(
                 DiscoveryConstants.WS_DISCOVERY_NAMESPACE, serviceName));
         newService.setId(serviceId);
-        newService.addAttribute(SERVICE_VERSION_PREFIX, DEFAULT_SERVICE_VERSION);
+
         // Set the version if provided
         if (service.getMetadataVersion() != -1) {
             newService.addAttribute(DiscoveryConstants.ATTR_METADATA_VERSION,


### PR DESCRIPTION
Earlier the governance module was reading the default lifecycle configuration from CARBON_HOME/repository/resources/lifcycles/configurations.xml. I have changed this to read multiple files from the directory "CARBON_HOME/repository/resources/lifcycles/". 
After this changes, if we want to create a new lifecycle, we need to put our configuration file within this directory. Here the configuration file name should be same as the aspect name of the lifecycle.  So when committing this change,  the configuratons.xml file also should be renamed with the aspect name of the lifecycle.
i.e: CARBON_HOME/repository/resources/lifcycles/configurations.xml should be renamed to CARBON_HOME/repository/resources/lifcycles/ApplicationLifecycle.xml