### PR TITLE
Changed the code to read multiple lifecycle confiruration files from a d...

### DIFF
--- a/components/governance/org.wso2.carbon.governance.lcm/src/main/java/org/wso2/carbon/governance/lcm/internal/LCMServiceComponent.java
+++ b/components/governance/org.wso2.carbon.governance.lcm/src/main/java/org/wso2/carbon/governance/lcm/internal/LCMServiceComponent.java
@@ -15,6 +15,8 @@
  */
 package org.wso2.carbon.governance.lcm.internal;
 
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceRegistration;
 import org.osgi.service.component.ComponentContext;
 import org.wso2.carbon.CarbonConstants;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
@@ -25,6 +27,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.core.services.callback.LoginSubscriptionManagerService;
 import org.wso2.carbon.registry.core.utils.UUIDGenerator;
+import org.wso2.carbon.utils.Axis2ConfigurationContextObserver;
 import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 
 /**
@@ -33,16 +36,26 @@ import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
  * @scr.reference name="registry.service"
  * interface="org.wso2.carbon.registry.core.service.RegistryService" cardinality="1..1"
  * policy="dynamic" bind="setRegistryService" unbind="unsetRegistryService"
- * @scr.reference name="login.subscription.service"
- * interface="org.wso2.carbon.core.services.callback.LoginSubscriptionManagerService" cardinality="0..1"
- * policy="dynamic" bind="setLoginSubscriptionManagerService" unbind="unsetLoginSubscriptionManagerService"
  */
 public class LCMServiceComponent {
 
     private static Log log = LogFactory.getLog(LCMServiceComponent.class);
 
     protected void activate(ComponentContext context) {
-        log.debug("******* Governance Life Cycle Management Service bundle is activated ******* ");
+        BundleContext bundleContext = context.getBundleContext();
+        LifecycleLoader lifecycleLoader = new LifecycleLoader();
+        ServiceRegistration tenantMgtListenerSR = bundleContext.registerService(
+                Axis2ConfigurationContextObserver.class.getName(), lifecycleLoader, null);
+        if (tenantMgtListenerSR != null) {
+            if(log.isDebugEnabled()) {
+                log.debug("Governance Life Cycle Management - LifecycleLoader registered");
+            }
+        } else {
+            log.error("Governance Life Cycle Management - LifecycleLoader could not be registered");
+        }
+        if (log.isDebugEnabled()) {
+            log.debug("Governance Life Cycle Management Service bundle is activated");
+        }
     }
 
     protected void deactivate(ComponentContext context) {
@@ -58,7 +71,7 @@ public class LCMServiceComponent {
         // Generate LCM search query if it doesn't exist.
         try {
             CommonUtil.addDefaultLifecyclesIfNotAvailable(registryService.getConfigSystemRegistry(),
-                    registryService.getRegistry(CarbonConstants.REGISTRY_SYSTEM_USERNAME), false);
+                    registryService.getRegistry(CarbonConstants.REGISTRY_SYSTEM_USERNAME));
         } catch (Exception e) {
             log.error("An error occurred while setting up Governance Life Cycle Management", e);
         }
@@ -66,14 +79,5 @@ public class LCMServiceComponent {
 
     protected void unsetRegistryService(RegistryService registryService) {
         CommonUtil.setRegistryService(null);
-    }
-
-    protected void setLoginSubscriptionManagerService(LoginSubscriptionManagerService loginManager) {
-        log.debug("******* LoginSubscriptionManagerServic is set ******* ");
-        loginManager.subscribe(new LifecycleLoader());
-    }
-
-    protected void unsetLoginSubscriptionManagerService(LoginSubscriptionManagerService loginManager) {
-        log.debug("******* LoginSubscriptionManagerServic is unset ******* ");
     }
 }

--- a/components/governance/org.wso2.carbon.governance.lcm/src/main/java/org/wso2/carbon/governance/lcm/util/CommonUtil.java
+++ b/components/governance/org.wso2.carbon.governance.lcm/src/main/java/org/wso2/carbon/governance/lcm/util/CommonUtil.java
@@ -518,13 +518,16 @@ public class CommonUtil {
                         //here we are checking the file name and aspect name to enforce that, both are same
                         OMElement omElement = buildOMElement(fileContent);
                         String aspectName = omElement.getAttributeValue(new QName("name"));
-                        if(!fileName.equalsIgnoreCase(aspectName)){
-                            String msg = String.format("Configuration file name %s not matched with aspect name %s ", fileName, aspectName );
+                        if (fileName.equalsIgnoreCase(aspectName)) {
+                            addLifecycle(fileContent, registry, rootRegistry);
+                        } else {
+                            String msg = String.format("Configuration file name %s not matched with aspect name %s ",
+                                                       fileName, aspectName);
                             log.error(msg);
                             /* The error is not thrown, because if we throw the error, the for loop will be broken and
                             other files won't be read */
                         }
-                        addLifecycle(fileContent, registry, rootRegistry);
+
                     } catch (RegistryException e) {
                         String msg = String.format("Error while adding aspect %s ", fileName);
                         log.error(msg, e);


### PR DESCRIPTION
...irectory, intstead of a single file

Earlier the governance module was reading the default lifecycle configuration from CARBON_HOME/repository/resources/lifcycles/configurations.xml. I have changed this to read multiple files from the directory "CARBON_HOME/repository/resources/lifcycles/". 
After this changes, if we want to create a new lifecycle, we need to put our configuration file within this directory. Here the configuration file name should be same as the aspect name of the lifecycle